### PR TITLE
Fixing missing .sort() in sim_meiosis.cpp for m = 0.

### DIFF
--- a/src/sim_meiosis.cpp
+++ b/src/sim_meiosis.cpp
@@ -21,7 +21,8 @@ NumericVector sim_crossovers(const double L, const int m, const double p,
             n_xo = R::rpois(L/100.0);
         }
         
-        return runif(n_xo, 0.0, L);
+        NumericVector tmp = runif(n_xo, 0.0, L);
+        return tmp.sort();
     }
 
     int n_points, first, n_nichi, n_ichi;


### PR DESCRIPTION
Dear Prof. Broman,
I'm using code of your simcross package in one of my own projects and noticed that you might have missed sorting the return value of the function sim_crossover() for the case where m = 0. As far as I can see, the function sim_meiosis() relies on the return value of sim_crossover being increasingly sorted.

Best 
Dominik